### PR TITLE
Update SV-260526.rb

### DIFF
--- a/controls/SV-260526.rb
+++ b/controls/SV-260526.rb
@@ -32,7 +32,7 @@ Restart the SSH daemon for the changes to take effect:
   tag 'container-conditional'
 
   describe sshd_config do
-    its('PermitUserEnvironment') { should cmp 'nil' }
-    its('PermitEmptyPasswords') { should cmp 'nil' }
+    its('PermitUserEnvironment') { should cmp 'no' }
+    its('PermitEmptyPasswords') { should cmp 'no' }
   end
 end


### PR DESCRIPTION
```
  ×  SV-260526: Ubuntu 22.04 LTS must not allow unattended or automatic login via SSH. (2 failed)
     ×  SSHD Configuration PermitUserEnvironment is expected to cmp == "nil"

     expected: nil
          got:

     (compared using `cmp` matcher)

     ×  SSHD Configuration PermitEmptyPasswords is expected to cmp == "nil"

     expected: nil
          got: no
```

no is correct. nil is not